### PR TITLE
Added ability to create mock PDF files (or any other files)

### DIFF
--- a/ddmock/src/main/java/com/dd/DDMock.kt
+++ b/ddmock/src/main/java/com/dd/DDMock.kt
@@ -2,10 +2,12 @@ package com.dd
 
 import android.app.Application
 import android.content.res.AssetManager
+import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl
+import okhttp3.MediaType
 import okio.Buffer
 import java.io.IOException
 import java.util.regex.Pattern
@@ -35,10 +37,11 @@ object DDMock {
             } else {
                 val fullFilePath = "$path/$file"
                 val key = path.replace(MOCK_FILE_DIRECTORY, "")
+                val extension = fullFilePath.split("/", ".").last()
                 if (result.contains(key)) {
                     result[key]?.files?.add(fullFilePath)
                 } else {
-                    result[key] = com.dd.MockEntry(key, arrayListOf(fullFilePath))
+                    result[key] = com.dd.MockEntry(key, arrayListOf(fullFilePath), mediaType2 = getMediaType(extension))
                 }
             }
         }
@@ -61,6 +64,14 @@ object DDMock {
         val path = urlPathBuilder.toString()
         val mockEntry = mockEntries[path]
         return mockEntry ?: getRegexEntry(path)
+    }
+
+    private fun getMediaType(extension: String): MediaType? {
+        when (extension) {
+            "json" -> return MediaType.parse(MockEntry.CONTENT_TYPE_APPLICATION_JSON)
+            "pdf" -> return MediaType.parse(MockEntry.CONTENT_TYPE_APPLICATION_PDF)
+        }
+        return MediaType.parse(MockEntry.CONTENT_TYPE_APPLICATION_JSON)
     }
 
     private fun getRegexEntry(path: String): MockEntry? {

--- a/ddmock/src/main/java/com/dd/DDMock.kt
+++ b/ddmock/src/main/java/com/dd/DDMock.kt
@@ -2,7 +2,6 @@ package com.dd
 
 import android.app.Application
 import android.content.res.AssetManager
-import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -41,7 +40,7 @@ object DDMock {
                 if (result.contains(key)) {
                     result[key]?.files?.add(fullFilePath)
                 } else {
-                    result[key] = com.dd.MockEntry(key, arrayListOf(fullFilePath), mediaType2 = getMediaType(extension))
+                    result[key] = com.dd.MockEntry(key, arrayListOf(fullFilePath), mediaType = getMediaType(extension))
                 }
             }
         }

--- a/ddmock/src/main/java/com/dd/MockEntry.kt
+++ b/ddmock/src/main/java/com/dd/MockEntry.kt
@@ -12,11 +12,10 @@ class MockEntry(
         var selectedFile: Int = 0,
         var statusCode: Int = HttpURLConnection.HTTP_OK,
         var responseTime: Long = DEFAULT_MOCK_RESPONSE_DELAY_MS,
-        var mediaType2: MediaType?
+        var mediaType: MediaType?
 ) {
         companion object {
                 const val CONTENT_TYPE_APPLICATION_JSON = "application/json; charset=utf-8"
                 const val CONTENT_TYPE_APPLICATION_PDF = "application/pdf; charset=utf-8"
         }
-    val mediaType = MediaType.parse(CONTENT_TYPE_APPLICATION_JSON)
 }

--- a/ddmock/src/main/java/com/dd/MockEntry.kt
+++ b/ddmock/src/main/java/com/dd/MockEntry.kt
@@ -3,7 +3,7 @@ package com.dd
 import okhttp3.MediaType
 import java.net.HttpURLConnection
 
-internal const val CONTENT_TYPE_APPLICATION_JSON = "application/json; charset=utf-8"
+
 private const val DEFAULT_MOCK_RESPONSE_DELAY_MS = 400L
 
 class MockEntry(
@@ -11,7 +11,12 @@ class MockEntry(
         val files: ArrayList<String>,
         var selectedFile: Int = 0,
         var statusCode: Int = HttpURLConnection.HTTP_OK,
-        var responseTime: Long = DEFAULT_MOCK_RESPONSE_DELAY_MS
+        var responseTime: Long = DEFAULT_MOCK_RESPONSE_DELAY_MS,
+        var mediaType2: MediaType?
 ) {
+        companion object {
+                const val CONTENT_TYPE_APPLICATION_JSON = "application/json; charset=utf-8"
+                const val CONTENT_TYPE_APPLICATION_PDF = "application/pdf; charset=utf-8"
+        }
     val mediaType = MediaType.parse(CONTENT_TYPE_APPLICATION_JSON)
 }

--- a/ddmock/src/main/java/com/dd/MockInterceptor.kt
+++ b/ddmock/src/main/java/com/dd/MockInterceptor.kt
@@ -36,10 +36,10 @@ class MockInterceptor : Interceptor {
             .message("MOCK")
             .header(
                 "Content-Type",
-                if (mockEntry.mediaType != null) mockEntry.mediaType.toString() else CONTENT_TYPE_APPLICATION_JSON
+                if (mockEntry.mediaType2 != null) mockEntry.mediaType2.toString() else MockEntry.CONTENT_TYPE_APPLICATION_JSON
             )
             .request(request)
-            .body(ResponseBody.create(mockEntry.mediaType, buffer.size(), buffer))
+            .body(ResponseBody.create(mockEntry.mediaType2, buffer.size(), buffer))
             .build()
     }
 }

--- a/ddmock/src/main/java/com/dd/MockInterceptor.kt
+++ b/ddmock/src/main/java/com/dd/MockInterceptor.kt
@@ -36,10 +36,10 @@ class MockInterceptor : Interceptor {
             .message("MOCK")
             .header(
                 "Content-Type",
-                if (mockEntry.mediaType2 != null) mockEntry.mediaType2.toString() else MockEntry.CONTENT_TYPE_APPLICATION_JSON
+                if (mockEntry.mediaType != null) mockEntry.mediaType.toString() else MockEntry.CONTENT_TYPE_APPLICATION_JSON
             )
             .request(request)
-            .body(ResponseBody.create(mockEntry.mediaType2, buffer.size(), buffer))
+            .body(ResponseBody.create(mockEntry.mediaType, buffer.size(), buffer))
             .build()
     }
 }


### PR DESCRIPTION
Just changes the content type of the interceptor to reflect based on the files extension. This should make it able to also read every single MIME type if you add the content key in to the MockEntry's init.

There is a tech branch where it matters that demos this.